### PR TITLE
Fixed Nexus 5X Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ The device must be plugged into a computer and not an AC power outlet whilst tes
 Currently supported devices:
 
 - Huawei Nexus 6P (angler)
+- LG Nexus 5X (bullhead)
 
 ###### Info
 

--- a/app/src/main/java/jacob/uk/com/usbcheck/MainActivity.java
+++ b/app/src/main/java/jacob/uk/com/usbcheck/MainActivity.java
@@ -52,16 +52,19 @@ public class MainActivity extends AppCompatActivity {
             }
         } catch (IOException e) {
             e.printStackTrace();
+
+            //inform the user of an error instead of leaving them questioning the app
+            readError();
         }
     }
 
     public void bullheadCheck() {
         try {
-            //Director detection code adapted from https://gist.github.com/ghoff/53608a5f3cf746c204a3
+            //Directory detection code adapted from https://gist.github.com/ghoff/53608a5f3cf746c204a3
 
             File baseDir = new File("/sys/bus/i2c/drivers/fusb301/");
             File[] files = baseDir.listFiles();
-            String dir = "*";
+            String dir = "*"; //keep the wildcard in case, for some reason, something fails
 
             for(int i=0; i<files.length; i++){
                 if(files[i].isDirectory()){
@@ -78,6 +81,9 @@ public class MainActivity extends AppCompatActivity {
             }
         } catch (IOException e) {
             e.printStackTrace();
+
+            //inform the user of an error instead of leaving them questioning the app
+            readError();
         }
     }
 
@@ -100,6 +106,17 @@ public class MainActivity extends AppCompatActivity {
         status.setImageResource(tick);
         statusText.setText("Cable is safe to use.");
         moreDetails.setText("This cable is USB-C compliant and drawing under 3As of power from the source.\n\nNot guaranteed to be 100% accurate, always apply caution when using electrical outlets.\n\nDevice: ");
+        moreDetails.append(device);
+    }
+
+    private void readError(){
+        final ImageView status = (ImageView) findViewById(R.id.status);
+        final TextView statusText = (TextView) findViewById(R.id.status_text);
+        final TextView moreDetails = (TextView) findViewById(R.id.more_details);
+
+        status.setImageResource(line);
+        statusText.setText("Failed to read current!");
+        moreDetails.setText("Something went wrong while trying to read the USB current! Try unplugging your device then plugging it back in.\n\nDevice: ");
         moreDetails.append(device);
     }
 

--- a/app/src/main/java/jacob/uk/com/usbcheck/MainActivity.java
+++ b/app/src/main/java/jacob/uk/com/usbcheck/MainActivity.java
@@ -10,6 +10,7 @@ import android.view.MenuItem;
 import android.widget.ImageView;
 import android.widget.TextView;
 
+import java.io.File;
 import java.io.IOException;
 
 import jacob.uk.com.usbcheck.events.BatteryChangeEvent;
@@ -56,7 +57,19 @@ public class MainActivity extends AppCompatActivity {
 
     public void bullheadCheck() {
         try {
-            String result = commandService.executeCommand("cat /sys/bus/i2c/drivers/fusb301/*/fclientcur");
+            //Director detection code adapted from https://gist.github.com/ghoff/53608a5f3cf746c204a3
+
+            File baseDir = new File("/sys/bus/i2c/drivers/fusb301/");
+            File[] files = baseDir.listFiles();
+            String dir = "*";
+
+            for(int i=0; i<files.length; i++){
+                if(files[i].isDirectory()){
+                    dir = files[i].getName();
+                }
+            }
+
+            String result = commandService.executeCommand("cat /sys/bus/i2c/drivers/fusb301/" + dir + "/fclientcur");
 
             if (Integer.parseInt(result) <= 1500) {
                 compliantCable();


### PR DESCRIPTION
In the version of the app currently on the Google Play Store, the app didn't function on the 5X. I've made a few changes to make it work, and also added a simple error message to make it clearer to the user if something goes wrong (it was frustrating just having a blank screen with an eye!). The app was tested on compliant cables, so I can't be 100% sure that it'll work with non-compliant ones. However, after doing some research, it should work as expected.